### PR TITLE
Fix write command for python3

### DIFF
--- a/etc/generate_actions.py
+++ b/etc/generate_actions.py
@@ -357,7 +357,7 @@ class ActionGenerator(object):
         action_filename = "{}/{}.yaml".format(ACTION_DIRECTORY,
                                               context['name'])
         with open(action_filename, "w") as f:
-            f.write(action_data.encode('ascii', 'ignore'))
+            f.write(action_data)
 
     def render_table_entry(self, context):
         table_data = self.jinja_render_file(TABLE_TEMPLATE_PATH, context)


### PR DESCRIPTION
Hello!

As mentioned in the chat a few days ago, I came across an error with python3 which I fixed by removed the `.encode` part of the write command. My python-fu is not that strong to ensure it is a proper fix, so please don't hesitate to suggest an improvement :-)

Cheers
Hannes