### PR TITLE
honor timeouts defined in the action

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v2.1.0
+
+* Timeouts defined in the action are now honored properly
+
 ## v2.0.0
 
 * Drop Python 2.7 support

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -112,13 +112,14 @@ class BaseAction(Action):
 
         # parse parameters
         operation = self._get_del_arg('operation', kwargs_dict)
+        timeout = self._get_del_arg('timeout', kwargs_dict)
         connection = self._resolve_connection(kwargs_dict)
         self._validate_connection(connection)
 
         # connect to the server
         client = foreman.client.Foreman('https://{}/'.format(connection['server']),
                                         auth=(connection['username'], connection['password']),
-                                        api_version=2)
+                                        api_version=2, timeout=timeout)
 
         # Performs a "deep" getattr() lookup so we can pass a string like
         # 'method1.method2.method3' without having to chain getattr()

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,7 +8,7 @@ keywords:
   - red
   - hat
   - redhat
-version: 2.0.0
+version: 2.1.0
 author: Daniel Chamot
 email: daniel@nullkarma.com
 python_versions:

--- a/tests/test_action_lib_baseaction.py
+++ b/tests/test_action_lib_baseaction.py
@@ -157,5 +157,5 @@ class TestActionLibBaseAction(ForemanBaseActionTestCase):
         self.assertEqual(result, op_result)
         mock_foreman.assert_called_with('https://{}/'.format(connection['server']),
                                         auth=(connection['username'], connection['password']),
-                                        api_version=2)
+                                        api_version=2, timeout=None)
         mock_func.assert_called_with(**op_args)


### PR DESCRIPTION
Hello!

As of now, the underlying Foreman library is using a timeout of 60 seconds ( https://python-foreman.readthedocs.io/en/latest/client/ ) which is not configurable in the given action.
Some actions are unfortunately long-running and I have to set this value.

Cheers
Hannes