### PR TITLE
hotfix/fix-ci-errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v2.1.1
+
+* Updated files to work with latest CI updates
+
 ## v2.1.0
 
 * Timeouts defined in the action are now honored properly

--- a/etc/generate_actions.py
+++ b/etc/generate_actions.py
@@ -6,7 +6,7 @@ import inspect
 import jinja2
 import os
 import re
-from six.moves.html_parser import HTMLParser
+import html
 
 import urllib3
 
@@ -286,8 +286,7 @@ class ActionGenerator(object):
         desc = desc.replace('"', "'")
 
         # convert HTML escaped sequences into ascii
-        htmlparser = HTMLParser()
-        desc = htmlparser.unescape(desc)
+        desc = html.unescape(desc)
 
         # remove HTML tags
         regex = re.compile('<.*?>')

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,7 +8,7 @@ keywords:
   - red
   - hat
   - redhat
-version: 2.1.0
+version: 2.1.1
 author: Daniel Chamot
 email: daniel@nullkarma.com
 python_versions:


### PR DESCRIPTION
Fixed files to work with latest CI updates

The unescape method was removed from the HTMLParser class in Python 3.4. Switched it to the recommended alternative from the last bullet here:
https://docs.python.org/3/whatsnew/3.9.html#removed